### PR TITLE
Throw errors during start instead of using fatalError

### DIFF
--- a/PeasyExample/PeasyExample/ViewController.swift
+++ b/PeasyExample/PeasyExample/ViewController.swift
@@ -15,7 +15,7 @@ final class ViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		server.start()
+		try! server.start()
 		server.respond(with: .image, when: .path(matches: "/image"))
 		server.respond(with: {
 			.json

--- a/PeasyExample/PeasyExample/ViewController.swift
+++ b/PeasyExample/PeasyExample/ViewController.swift
@@ -15,7 +15,7 @@ final class ViewController: UIViewController {
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
-		try! server.start()
+		server.start()
 		server.respond(with: .image, when: .path(matches: "/image"))
 		server.respond(with: {
 			.json

--- a/Sources/Peasy/Internal/Socket.swift
+++ b/Sources/Peasy/Internal/Socket.swift
@@ -22,9 +22,9 @@ final class Socket {
 		Darwin.close(tag)
 	}
 	
-	func bind(port: Int) {
+	func bind(port: Int) throws {
 		var reuse: Int32 = 1
-		guard setsockopt(tag, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size)) >= 0 else { fatalError(DarwinError().message) }
+		guard setsockopt(tag, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size)) >= 0 else { throw DarwinError() }
 		var address = sockaddr_in6()
 		address.sin6_len = UInt8(MemoryLayout<sockaddr_in6>.stride)
 		address.sin6_family = sa_family_t(AF_INET6)
@@ -32,14 +32,14 @@ final class Socket {
 		address.sin6_addr = .localhost
 		let size = socklen_t(MemoryLayout<sockaddr_in6>.size)
 		let success = withUnsafePointer(to: &address) { $0.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) { Darwin.bind(tag, $0, size) >= 0 } }
-		guard success else { fatalError(DarwinError().message) }
+		guard success else { throw DarwinError() }
 		print("Bound to port", port)
-		listen()
+		try listen()
 	}
 	
-	private func listen() {
+	private func listen() throws {
 		let success = Darwin.listen(tag, Int32(SOMAXCONN)) >= 0
-		guard success else { fatalError(DarwinError().message) }
+		guard success else { throw DarwinError() }
 		print("Listening on socket", tag)
 	}
 	

--- a/Sources/Peasy/Server.swift
+++ b/Sources/Peasy/Server.swift
@@ -31,9 +31,9 @@ public final class Server {
 	/// Starts the server on the specified port (or the default port if no port is specified)
 	///
 	/// It is an error to attempt to start more than one server on the same port without calling `stop`  on the previous servers first.
-	public func start(port: Int = 8880) {
+	public func start(port: Int = 8880) throws {
 		switch state {
-			case .notRunning: createSocket(bindingTo: port)
+			case .notRunning: try createSocket(bindingTo: port)
 			case .running: fatalError("Cannot start server because it's already started.")
 		}
 	}
@@ -93,9 +93,9 @@ public final class Server {
 	
 	// MARK: Private
 	
-	private func createSocket(bindingTo port: Int) {
+	private func createSocket(bindingTo port: Int) throws {
 		let socket = Socket()
-		socket.bind(port: port)
+		try socket.bind(port: port)
 		let eventListener = EventListener()
 		eventListener.register(socket) { [weak self] in
 			self?.handleIncomingConnection()

--- a/Sources/Peasy/Server.swift
+++ b/Sources/Peasy/Server.swift
@@ -14,6 +14,13 @@ import Foundation
 public final class Server {
 	
 	// MARK: - Properties -
+	// MARK: Public
+	
+	/// The port that the server has been started on
+	///
+	/// Returns nil if the server hasn't been started or has been stopped
+	public var port: Int?
+	
 	// MARK: Private
 	
 	private var state: State = .notRunning
@@ -30,7 +37,7 @@ public final class Server {
 	
 	/// Starts the server on the specified port (or the default port if no port is specified)
 	///
-	/// It is an error to attempt to start more than one server on the same port without calling `stop`  on the previous servers first.
+	/// An error will be thrown when starting more than one server on the same port without calling `stop`  on the previous servers first.
 	public func start(port: Int = 8880) throws {
 		switch state {
 			case .notRunning: try createSocket(bindingTo: port)
@@ -87,6 +94,7 @@ public final class Server {
 				connections.removeAll()
 				configurations.removeAll()
 				state = .notRunning
+				port = nil
 			case .notRunning: fatalError("Cannot stop server because it's not running.")
 		}
 	}
@@ -102,6 +110,7 @@ public final class Server {
 		}
 		eventListener.start()
 		state = .running(socket, eventListener)
+		self.port = port
 		print("Started server on port", port)
 	}
 	

--- a/Sources/Peasy/Server.swift
+++ b/Sources/Peasy/Server.swift
@@ -40,11 +40,11 @@ public final class Server {
 	
 	/// Starts the server on a port in the specified range, returns the port the server was started on.
 	///
-	/// It will error if there is no available port in the range.
-	public func start<T: Collection>(port portRange: T) -> Int where T.Element == Int {
+	/// It will error if there is no available port in the collection.
+	public func start<T: Collection>(port ports: T) -> Int where T.Element == Int {
 		switch state {
 			case .notRunning:
-				for port in portRange {
+				for port in ports {
 					do {
 						try createSocket(bindingTo: port)
 						return port


### PR DESCRIPTION
We run our UITests in parallel simulators so having it fatally error when the port is already in use doesn't work. Instead if we can catch the error then we can try on the next port. eg:

```
public static func start() {
	for i in 0..<10 {
		do {
			try server.start(port: 8090 + i)
			break
		} catch {}
	}
	guard let port = server.port else {
		fatalError("Couldn't start UI Test server")
	}
	print("Mock server started on port \(port)")
}
```


 Also storing the port allows it to be sent to the app being tested through an environment variable.

If you have a better or existing way of using it with parallel simulators that would be great :)