### PR TITLE
Change configuration priority and allow removal

### DIFF
--- a/Sources/Peasy/Server.swift
+++ b/Sources/Peasy/Server.swift
@@ -148,7 +148,7 @@ public final class Server {
 	
 	private func respond(with response: @escaping (Request) -> Response, when rules: [Rule], removeAfterResponding: Bool) {
 		let config = Configuration(response: response, rules: rules, removeAfterResponding: removeAfterResponding)
-		configurations.append(config)
+		configurations.insert(config, at: 0)
 	}
 	
 }

--- a/Sources/Peasy/Server.swift
+++ b/Sources/Peasy/Server.swift
@@ -77,6 +77,11 @@ public final class Server {
 		respond(with: response, when: rules, removeAfterResponding: removeAfterResponding)
 	}
 	
+	/// Removes all the previously set configurations without stopping the server
+	public func removeAllResponses() {
+ 		configurations.removeAll()
+ 	}
+	
 	/// Stops the server and frees up the port used when calling `start`.
 	public func stop() {
 		switch state {


### PR DESCRIPTION
I've started the Peasy mock server when the test run and kept it running across all the tests, and just remove the configurations after each test finishes. So needed a removeAllResponses method, if you don't like this, I start the mock server each time but it seemed more wasteful.

Also I think the configurations should be inserted at the beginning of the list so that responses set later during the test are found and sent back. eg (a bit contrived):

```
server.respond(with: emptyBasketResponse, when: .path(matches: "/basket"))
When(I: viewTheBasket())
Then(thereAreNoProductsVisible())
server.respond(with: oneProductBasketResponse, when: .path(matches: "/basket"))
When(I: addAProduct())
Then(thereAreIsOneProductsVisible())
```

Without inserting at the start of the list then it will still show the empty basket. But it seems like you might have had good reason to append it at the end?