### PR TITLE
Let operating system choose port

### DIFF
--- a/Sources/Peasy/Internal/Socket.swift
+++ b/Sources/Peasy/Internal/Socket.swift
@@ -30,7 +30,7 @@ final class Socket {
 		address.sin6_port = UInt16(port).bigEndian
 		address.sin6_addr = .localhost
 		let size = socklen_t(MemoryLayout<sockaddr_in6>.size)
-		let success = withUnsafePointer(to: &address) { address -> Bool in
+		let success = withUnsafePointer(to: &address) { address in
 			return address.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) {
 				Darwin.bind(tag, $0, size) >= 0
 			}
@@ -39,10 +39,8 @@ final class Socket {
 		var usedAddressSize = socklen_t(MemoryLayout<sockaddr_in6>.size)
 		var usedAddress = sockaddr_in6()
 		_ = withUnsafeMutablePointer(to: &usedAddress) { usedAddress in
-			_ = withUnsafeMutablePointer(to: &usedAddressSize) { usedAddressSize in
-				usedAddress.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) {
-					Darwin.getsockname(tag, $0, usedAddressSize)
-				}
+            usedAddress.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) {
+                Darwin.getsockname(tag, $0, &usedAddressSize)
 			}
 		}
 

--- a/Sources/Peasy/Internal/Socket.swift
+++ b/Sources/Peasy/Internal/Socket.swift
@@ -21,7 +21,7 @@ final class Socket {
 		Darwin.close(tag)
 	}
 	
-	func bind(port: Int) {
+	func bind(port: Int) -> Int {
 		var reuse: Int32 = 1
 		guard setsockopt(tag, SOL_SOCKET, SO_REUSEADDR, &reuse, socklen_t(MemoryLayout<Int32>.size)) >= 0 else { fatalError(DarwinError().message) }
 		var address = sockaddr_in6()
@@ -30,9 +30,26 @@ final class Socket {
 		address.sin6_port = UInt16(port).bigEndian
 		address.sin6_addr = .localhost
 		let size = socklen_t(MemoryLayout<sockaddr_in6>.size)
-		let success = withUnsafePointer(to: &address) { $0.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) { Darwin.bind(tag, $0, size) >= 0 } }
+		let success = withUnsafePointer(to: &address) { address -> Bool in
+			return address.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) {
+				Darwin.bind(tag, $0, size) >= 0
+			}
+		}
+
+		var usedAddressSize = socklen_t(MemoryLayout<sockaddr_in6>.size)
+		var usedAddress = sockaddr_in6()
+		_ = withUnsafeMutablePointer(to: &usedAddress) { usedAddress in
+			_ = withUnsafeMutablePointer(to: &usedAddressSize) { usedAddressSize in
+				usedAddress.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) {
+					Darwin.getsockname(tag, $0, usedAddressSize)
+				}
+			}
+		}
+
 		guard success else { fatalError(DarwinError().message) }
 		listen()
+
+		return Int(usedAddress.sin6_port.bigEndian)
 	}
 	
 	private func listen() {

--- a/Sources/Peasy/Server.swift
+++ b/Sources/Peasy/Server.swift
@@ -31,9 +31,12 @@ public final class Server {
 	/// Starts the server on the specified port (or the default port if no port is specified)
 	///
 	/// It is an error to attempt to start more than one server on the same port without calling `stop`  on the previous servers first.
-	public func start(port: Int = 8880) {
+	/// - Parameter port: The port that should be used to bind the server to. Specify port `0` to let the operating system choose an available port for you.
+	/// - Returns: Port the server listens on
+	@discardableResult
+	public func start(port: Int = 8880) -> Int {
 		switch state {
-			case .notRunning: createSocket(bindingTo: port)
+			case .notRunning: return createSocket(bindingTo: port)
 			case .running: fatalError("Cannot start server because it's already started.")
 		}
 	}
@@ -92,9 +95,9 @@ public final class Server {
 	
 	// MARK: Private
 	
-	private func createSocket(bindingTo port: Int) {
+	private func createSocket(bindingTo port: Int) -> Int {
 		let socket = Socket()
-		socket.bind(port: port)
+		let port = socket.bind(port: port)
 		let eventListener = EventListener()
 		eventListener.register(socket) { [weak self] in
 			self?.handleIncomingConnection()
@@ -102,6 +105,7 @@ public final class Server {
 		eventListener.start()
 		state = .running(socket, eventListener)
 		print("Started server on port", port)
+		return port
 	}
 	
 	private func handleIncomingConnection() {

--- a/Tests/PeasyTests/ServerTests.swift
+++ b/Tests/PeasyTests/ServerTests.swift
@@ -1,0 +1,27 @@
+import XCTest
+@testable import Peasy
+
+final class ServerTests: XCTestCase {
+
+    func testBindPort() throws {
+        let server = Server()
+        
+        let port = 8880
+        server.start(port: port)
+        server.respond(with: Response(status: .ok))
+        
+        let address = URL(string: "http://localhost:\(port)")!
+        
+        let expectation = self.expectation(description: "Completion")
+        let dataTask = URLSession.shared.dataTask(with: address) { (data, response, error) in
+            XCTAssertNil(error)
+            XCTAssertEqual((response as! HTTPURLResponse).statusCode, 200)
+            expectation.fulfill()
+            server.stop()
+        }
+        dataTask.resume()
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
+}
+    

--- a/Tests/PeasyTests/ServerTests.swift
+++ b/Tests/PeasyTests/ServerTests.swift
@@ -5,6 +5,23 @@ final class ServerTests: XCTestCase {
 
     func testBindPort() throws {
         let server = Server()
+        let port = 8880
+        let usedPort = server.start(port: port)
+        defer { server.stop() }
+        
+        XCTAssertEqual(port, usedPort)
+    }
+
+    func testSystemChosenPort() throws {
+        let server = Server()
+        let usedPort = server.start(port: 0)
+        defer { server.stop() }
+        
+        XCTAssert(usedPort > 0)
+    }
+
+    func testConnectionOnSpecifiedPort() throws {
+        let server = Server()
         
         let port = 8880
         server.start(port: port)
@@ -23,5 +40,24 @@ final class ServerTests: XCTestCase {
         
         wait(for: [expectation], timeout: 5.0)
     }
+
+    func testConnectionOnSystemChosenPort() throws {
+        let server = Server()
+        
+        let port = server.start(port: 0)
+        server.respond(with: Response(status: .ok))
+        
+        let address = URL(string: "http://localhost:\(port)")!
+        
+        let expectation = self.expectation(description: "Completion")
+        let dataTask = URLSession.shared.dataTask(with: address) { (data, response, error) in
+            XCTAssertNil(error)
+            XCTAssertEqual((response as! HTTPURLResponse).statusCode, 200)
+            expectation.fulfill()
+            server.stop()
+        }
+        dataTask.resume()
+        
+        wait(for: [expectation], timeout: 5.0)
+    }
 }
-    


### PR DESCRIPTION
When opening a unix socket, the system chooses a port for you, if you do not specify one (`port = 0`). This PR leverages this behaviour if you specify the port `0` on starting the server and returns the used port.

This PR adds new test cases and updates the documentation of the `Server.start(port)` method.

This fixes #27 and addresses the problem stated in #20 in a different but safer way.