### PR TITLE
Fix Xcode 14 runtime errors

### DIFF
--- a/Sources/Peasy/Internal/Socket.swift
+++ b/Sources/Peasy/Internal/Socket.swift
@@ -25,7 +25,7 @@ final class Socket {
 		enableAddressReuse()
 		var address: sockaddr_in6 = .localhost(port: port)
 		let size = MemoryLayout<sockaddr_in6>.size
-		let success = withUnsafePointer(to: &address) { $0.withMemoryRebound(to: sockaddr.self, capacity: size) { Darwin.bind(tag, $0, socklen_t(size)) >= 0 } }
+		let success = withUnsafePointer(to: &address) { $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.bind(tag, $0, socklen_t(size)) >= 0 } }
 		guard success else { fatalError(DarwinError().message) }
 		listen()
 		return boundPort()
@@ -45,7 +45,7 @@ final class Socket {
 	private func boundPort() -> Int {
 		var size = socklen_t(MemoryLayout<sockaddr_in6>.size)
 		var usedAddress = sockaddr_in6()
-		let success = withUnsafeMutablePointer(to: &usedAddress) { $0.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) { getsockname(tag, $0, &size) >= 0 } }
+		let success = withUnsafeMutablePointer(to: &usedAddress) { $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { getsockname(tag, $0, &size) >= 0 } }
 		guard success else { fatalError(DarwinError().message) }
 		return Int(usedAddress.sin6_port.bigEndian)
 	}
@@ -53,7 +53,7 @@ final class Socket {
 	func accept() -> Socket {
 		var address = sockaddr_in6()
 		var size = socklen_t(MemoryLayout<sockaddr_in6>.size)
-		let tag = withUnsafeMutablePointer(to: &address) { $0.withMemoryRebound(to: sockaddr.self, capacity: Int(size)) { Darwin.accept(self.tag, $0, &size) } }
+		let tag = withUnsafeMutablePointer(to: &address) { $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { Darwin.accept(self.tag, $0, &size) } }
 		guard tag >= 0 else { fatalError(DarwinError().message) }
 		return Socket(tag: tag)
 	}


### PR DESCRIPTION
@KaneCheshire the latest `Peasy` version available does not work with Xcode 14.x and Swift 5.7.

The capacity argument indicates the number of instances of `sockaddr_*` and not the number of bytes within the pointer. Fix based on https://git.zx2c4.com/wireguard-apple/commit/?h=am/fix-addrinfo-crash

Please, could this be merged and a new version be released?

Thank you for writing `Peasy` and contributing to the iOS development community. Good job.