### PR TITLE
Ignore errors for `EV_DELETE` in `EventListener`

### DIFF
--- a/Sources/Peasy/Internal/EventListener.swift
+++ b/Sources/Peasy/Internal/EventListener.swift
@@ -48,7 +48,7 @@ final class EventListener {
 		var events = [kevent(ident: UInt(socket), filter: Int16(EVFILT_READ), flags: UInt16(state), fflags: 0, data: 0, udata: nil)]
 		let eventCount = events.count
 		let success = events.withUnsafeMutableBufferPointer { kevent(queue, $0.baseAddress, Int32(eventCount), nil, 0, nil) >= 0 }
-		guard success else { fatalError(DarwinError().message) }
+		guard state == EV_DELETE || success else { fatalError(DarwinError().message) }
 	}
 	
 	private func events() -> [Int32] {


### PR DESCRIPTION
During tests execution, we've experienced the following error multiple times:

```
Peasy/EventListener.swift:51: Fatal error: No such file or directory
```

Environment:
- Xcode 14.2
- macOS Monterrey 12.6 / macOS Ventura 13.2

After debugging, we noticed this is eventually received upon `server.stop()` invocation. The server was being started without any specific port, so `Peasy` looked for an available one. The `fatalError` invocation causes the test execution to fail even when tests pass.

In my opinion, this can be ignored for `EV_DELETE`. `server.stop()` is usually invoked within `tearDown()` so whatever happens to `server` while stopping is irrelevant for test execution results. 